### PR TITLE
Fix run of trim.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Compress TitleDB for use with Tinfoil as an index
         run: |
           (echo '{ "titledb": '; cat titles.US.en.json; echo "}") > titlesIndex.json
+          # Workspace is overrided by arch-box/nut, so we need to wget the trim.py
+          wget https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/trim.py -O trim.py
           python3 trim.py titlesIndex.json
           wget https://blawar.github.io/tinfoil/files/encrypt.py
           wget https://blawar.github.io/tinfoil/files/public.key


### PR DESCRIPTION
trim.py was not found due to workspace being erased by arch-box/nut repository.
https://github.com/AdamK2003/titledb/blob/main/.github/workflows/main.yml#L23
